### PR TITLE
[libiodata-qt5] Explicitly depend on pkgconfig(libcrypt). JB#54931

### DIFF
--- a/rpm/libiodata-qt5.spec
+++ b/rpm/libiodata-qt5.spec
@@ -7,6 +7,7 @@ License:  LGPLv2
 URL:      https://git.sailfishos.org/mer-core/libiodata
 Source0:  %{name}-%{version}.tar.bz2
 
+BuildRequires: pkgconfig(libcrypt)
 BuildRequires: pkgconfig(Qt5Core)
 BuildRequires: bison
 BuildRequires: flex


### PR DESCRIPTION
libiodata-qt5 depdends on pkconfig(libcrypt) for the crypt import but it was
not included. This fails when pkconfig(libcrypt) is not bundled in the glib-devel package.