### PR TITLE
[libiodata] Adjust feature name in the unit test declaration. Fixes JB#57893

### DIFF
--- a/rpm/libiodata-qt5.spec
+++ b/rpm/libiodata-qt5.spec
@@ -4,7 +4,7 @@ Version:  0.19.8
 Release:  1
 Summary:  Library for input/ouput data
 License:  LGPLv2
-URL:      https://git.sailfishos.org/mer-core/libiodata
+URL:      https://github.com/sailfishos/libiodata
 Source0:  %{name}-%{version}.tar.bz2
 
 BuildRequires: pkgconfig(libcrypt)
@@ -17,7 +17,6 @@ This package provides a library for writing and reading structured data.
 
 %package devel
 Summary:  Development package for %{name}
-Group:    Development/Libraries
 Requires: pkgconfig(Qt5Core)
 Requires: %{name} = %{version}-%{release}
 
@@ -26,7 +25,6 @@ Provides header files for iodata library.
 
 %package tests
 Summary:  Testcases for iodata library
-Group:    Development/System
 Requires: testrunner-lite
 
 %description tests

--- a/tests/tests.xml.in
+++ b/tests/tests.xml.in
@@ -1,6 +1,6 @@
 <testdefinition version="0.1">
   <suite name="@PACKAGENAME@-tests" domain="System Software">
-    <set name="@PACKAGENAME@-simple_tests" description="basic iodata functionality" feature="System Control" requirement="MaSSW-815, MaSSW-1167">
+    <set name="@PACKAGENAME@-simple_tests" description="basic iodata functionality" feature="Libiodata" requirement="MaSSW-815, MaSSW-1167">
       <environments><scratchbox>false</scratchbox><hardware>true</hardware></environments>
       <case name="trivial" description="parse a trivial structure from a string" subfeature="TimeAlarm">
         <step>@PATH@/@PACKAGENAME@-test trivial</step>


### PR DESCRIPTION
Current test setup shows the tests without iodata context. The
tests.xml handling could be enhanced there, but just adjusting the
string here is easy enough as commonly the other packages have enough
context on the feature name.

@Tomin1 @spiiroin 