### PR TITLE
Fix dependencies between sub-projects

### DIFF
--- a/root.pro
+++ b/root.pro
@@ -2,6 +2,9 @@ TEMPLATE = subdirs
 
 SUBDIRS = src tests type-to-cxx
 
+tests.depends = src
+type-to-cxx.depends = src
+
 prf.path =  $$[QT_HOST_DATA]/mkspecs/features
 
 equals(QT_MAJOR_VERSION, 5): prf.files = iodata-qt5.prf


### PR DESCRIPTION
`test` & `type-to-c++` projects link against `iodata-qt{5,6}`, but didn't declare this dependency. This causes an attempted link of `type-to-c++` against not-yet-built `iodata-qt{5,6}` when building with enough parallelism.

Declare the dependency, so build parallelism works properly.

---

```
make[1]: Entering directory '/build/source/src'
g++ -c -pipe -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/include/QtCore -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/mkspecs/linux-g++ -o iodata.o iodata.cpp
g++ -c -pipe -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/include/QtCore -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/mkspecs/linux-g++ -o validator.o validator.cpp
g++ -c -pipe -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/include/QtCore -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/mkspecs/linux-g++ -o storage.o storage.cpp
make[1]: Entering directory '/build/source/type-to-cxx'
g++ -c -pipe -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/include/QtCore -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/mkspecs/linux-g++ -o type-to-cxx.o type-to-cxx.cpp
g++ -c -pipe -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/include/QtCore -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/mkspecs/linux-g++ -o misc.o misc.cpp
bison -v -d -o parser.cpp datalang.y
make[1]: Entering directory '/build/source/tests'
sed -e s:@PACKAGENAME@:iodata-qt5:g -e 's%@PATH@%/nix/store/pc0kg6sqhsha32gpzbi3vp03yk7a8i59-libiodata-0.19.14/bin%' /build/source/tests/tests.xml.in > tests.xml
g++ -c -pipe -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/include/QtCore -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/mkspecs/linux-g++ -o iodata-test.o iodata-test.cpp
datalang.y:1.1-12: warning: deprecated directive: '%pure-parser', use '%define api.pure' [-Wdeprecated]
    1 | %pure-parser
      | ^~~~~~~~~~~~
      | %define api.pure
datalang.y:2.1-22: warning: deprecated directive: '%name-prefix="iodata_"', use '%define api.prefix {iodata_}' [-Wdeprecated]
    2 | %name-prefix="iodata_"
      | ^~~~~~~~~~~~~~~~~~~~~~
      | %define api.prefix {iodata_}
datalang.y:5.1-14: warning: deprecated directive: '%error-verbose', use '%define parse.error verbose' [-Wdeprecated]
    5 | %error-verbose
      | ^~~~~~~~~~~~~~
      | %define parse.error verbose
datalang.y: warning: fix-its can be applied.  Rerun with option '--update'. [-Wother]
g++ -c -pipe -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/include/QtCore -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/mkspecs/linux-g++ -o parser.o parser.cpp
true
flex -o tokens.cpp datalang.l
g++ -c -pipe -O2 -Wall -Wextra -D_REENTRANT -fPIC -DQT_NO_DEBUG -DQT_CORE_LIB -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/include/QtCore -I. -I/nix/store/w0r1625warqlz1hjpz09harg8hkxhz1v-qtbase-5.15.15-dev/mkspecs/linux-g++ -o tokens.o tokens.cpp
g++ -Wl,-O1 -Wl,-rpath,/nix/store/ab0h94ds17b7d2q3k2wa9rcc1nzxj3x4-qtbase-5.15.15/lib -o iodata-qt5-test iodata-test.o   -L../src -liodata-qt5 /nix/store/ab0h94ds17b7d2q3k2wa9rcc1nzxj3x4-qtbase-5.15.15/lib/libQt5Core.so -pthread   
/nix/store/bwkb907myixfzzykp21m9iczkhrq5pfy-binutils-2.43.1/bin/ld: cannot find -liodata-qt5: No such file or directory
collect2: error: ld returned 1 exit status
```

https://wiki.qt.io/SUBDIRS_-_handling_dependencies#Defining_Project_Dependencies:_.depends_attributes